### PR TITLE
Fixed a bug in which the selection was not made even if it was selected again.

### DIFF
--- a/src/js/nice-select2.js
+++ b/src/js/nice-select2.js
@@ -313,7 +313,7 @@ NiceSelect.prototype._onItemClicked = function(option, e) {
       if (hasClass(optionEl, "selected")) {
 		removeClass(optionEl, "selected");
 		this.selectedOptions.splice(this.selectedOptions.indexOf(option),1);
-		this.el.querySelector('option[value="' + optionEl.dataset.value + '"]').selected=false;
+		this.el.querySelector('option[value="' + optionEl.dataset.value + '"]').removeAttribute('selected');
 	  }else{
         addClass(optionEl, "selected");
         this.selectedOptions.push(option);


### PR DESCRIPTION
Thanks for the great library.

Fixed a bug that when the multiple option was enabled, it was not enabled even if the choice was selected again.

### Steps to Reproduce

- Set multiple option `<select multiple="multiple">` 
- Click on an option
  - `document.querySelector('select').selectedOptions.length` equals `1`
- Click on an option
  - `document.querySelector('select').selectedOptions.length` equals `0`
- Click on a choice and select again
  - `document.querySelector('select').selectedOptions.length` equals `0` // NG, expect 1