### PR TITLE
Added option to show selected items

### DIFF
--- a/src/js/nice-select2.js
+++ b/src/js/nice-select2.js
@@ -48,7 +48,8 @@ function removeClass(el, className) {
 
 var defaultOptions = {
   data: null,
-  searchable: false
+  searchable: false,
+  showSelectedItems: false
 };
 export default function NiceSelect(element, options) {
   this.el = element;
@@ -166,7 +167,7 @@ NiceSelect.prototype.renderDropdown = function() {
 NiceSelect.prototype._renderSelectedItems = function() {
   if (this.multiple) {
     var selectedHtml = "";
-	if(window.getComputedStyle(this.dropdown).width == 'auto' || this.selectedOptions.length <2){
+	if(this.config.showSelectedItems || window.getComputedStyle(this.dropdown).width == 'auto' || this.selectedOptions.length <2){
 		this.selectedOptions.forEach(function(item) {
 		  selectedHtml += `<span class="current">${item.data.text}</span>`;
 		});


### PR DESCRIPTION
Proposal.

Add option to display items selected by multiple attributes. This option allows for flexibility in the way it looks.

For example, in CSS, it can be displayed comma-separated.

```scss
.nice-select.has-multiple {
  .multiple-options {
    display: block;
    text-overflow: ellipsis;
    white-space: nowrap;
    overflow: hidden;
  }
  .current {
    &:before {
      content: ' , ';
    }
    &:first-of-type {
      &:before {
        content: '';
      }
    }
  }
}
```