### PR TITLE
Added ability to close multiple dropdown from top span element

### DIFF
--- a/src/js/nice-select2.js
+++ b/src/js/nice-select2.js
@@ -332,9 +332,17 @@ NiceSelect.prototype._onClicked = function(e) {
 	if (!hasClass(this.dropdown, "open") ) {
 		addClass(this.dropdown, "open");
     triggerModalOpen(this.el);
-	}else if(!this.multiple){
-		removeClass(this.dropdown, "open");
-    triggerModalClose(this.el);
+	} else {
+		if (this.multiple) {
+		  if (e.target == this.dropdown.querySelector('.multiple-options')) {
+			removeClass(this.dropdown, "open");
+			triggerModalClose(this.el);
+		  }
+
+		} else {
+		  removeClass(this.dropdown, "open");
+		  triggerModalClose(this.el);
+		}
 	}
 
   if (hasClass(this.dropdown, "open")) {


### PR DESCRIPTION
So the multiple select does not allow to close whole dropdown by clicking on the top element. I've added ability for closing dropdown by clicking on the top span. I think with that logic we can move some top styles (spacings, arrow, etc.) to this <span> element so the clicking area would be bigger.