### PR TITLE
Fixed `syncSelectValue()` for `data-display`

### DIFF
--- a/src/js/nice-select2.js
+++ b/src/js/nice-select2.js
@@ -454,7 +454,7 @@ class NiceSelect {
       }
 
       if (matchingOption == undefined) {
-        // no matching option was found, continue
+        console.warn(`No matching option found for value: "${item.data.value}" in select element`, select);
         return;
       }
 

--- a/src/js/nice-select2.js
+++ b/src/js/nice-select2.js
@@ -439,16 +439,23 @@ class NiceSelect {
     }
 
     this.options.forEach(item =>{
-      let option   = Array.from(select.options).find(option => option.textContent === item.data.text);
+      let matchingOption = Array.from(select.options).find(option => {
+        return (option.dataset.display || option.textContent) === item.data.text;
+      });
 
-      if(option == undefined){
-        option   = Array.from(select.options).find(option => option.textContent === item.data.value);
+      if(matchingOption == undefined){
+        matchingOption = Array.from(select.options).find(option => option.textContent === item.data.value);
+      }
+
+      if (matchingOption == undefined) {
+        // no matching option was found, continue
+        return;
       }
 
       if(item.attributes.selected){
-        option.selected = true;
+        matchingOption.selected = true;
       } else {
-        option.selected = false;
+        matchingOption.selected = false;
       }
     });
 

--- a/src/js/nice-select2.js
+++ b/src/js/nice-select2.js
@@ -440,11 +440,17 @@ class NiceSelect {
 
     this.options.forEach(item =>{
       let matchingOption = Array.from(select.options).find(option => {
-        return (option.dataset.display || option.textContent) === item.data.text;
+        const a = String(option.dataset.display || option.textContent).trim().toLowerCase();
+        const b = String(item.data.text).trim().toLowerCase();
+        return a === b;
       });
 
       if(matchingOption == undefined){
-        matchingOption = Array.from(select.options).find(option => option.textContent === item.data.value);
+        matchingOption = Array.from(select.options).find(option => {
+          const a = String(option.value).trim().toLowerCase();
+          const b = String(item.data.value).trim().toLowerCase();
+          return a === b;
+        });
       }
 
       if (matchingOption == undefined) {


### PR DESCRIPTION
The changes in this PR address issue #99 by allowing `syncSelectValue()` to take `data-display` into account when searching for an option matching each item in the dropdown list.

This solution is fully tested in a local environment and confirmed to work regardless of `data-display` being used or not.

The name `matchingOption` was used for the variable in the outer scope, so that there is no confusion with the `option` variable used inside the `find` callback functions. While the previous naming doesn't create any functional problem, the new one makes the code easier to read.

## Summary by Sourcery

Fix syncSelectValue to account for the data-display attribute when matching dropdown options and improve variable naming for clarity.

Bug Fixes:
- Allow syncSelectValue to match options based on the data-display attribute (or text content) in a case-insensitive manner and fallback to matching by value if no display match is found

Enhancements:
- Rename the inner variable from option to matchingOption to avoid confusion and improve code readability